### PR TITLE
Refactor `TERM` computation for better portability

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -9,28 +9,6 @@ set-option -ga update-environment " LC_TERMINAL"
 set-option -ga update-environment " TERM_PROGRAM"
 
 set-hook -ga session-created {
-    #===========
-    # TERM
-    #===========
-    # Use TERM of tmux when possible
-    # Check host for tmux terminfo
-    if-shell ' \
-        infocmp "tmux" \
-    ' \
-    {
-        set-option default-terminal "tmux"
-    }
-
-    # Add `-256color` to TERM when possible
-    # Check max color supported is 256 and that host has terminfo for $TERM-256color
-    if-shell ' \
-        [ "$(tput colors)" = "256" ] && \
-        infocmp "#{default-terminal}-256color" \
-    ' \
-    {
-        set-option -a default-terminal "-256color"
-    }
-
     if-shell ' \
         [ -n "$TERM" ] && \
         [ -n "$COLORTERM" ] && \
@@ -51,7 +29,38 @@ set-hook -ga client-attached {
     set-hook -R session-created
 }
 
-set-hook -R session-created
+set-option -g default-command ' \
+: " \
+Comments are written in this format to maintain POSIX compliance and because \
+the #-method of commenting is incompatible with single-line commands. \
+https://stackoverflow.com/a/2524407 \
+"; \
+\
+: " \
+Attempt to use TERM of tmux when possible. \
+Check host for tmux terminfo. \
+"; \
+if infocmp "tmux" > /dev/null 2>&1; then \
+    TERM="tmux"; \
+fi; \
+\
+: " \
+Append \"-256color\" to TERM when possible. \
+Check that the client terminal supports 256 color and verify that there is a \
+terminfo entry for $TERM-256color. \
+"; \
+client_termname=$(tmux display-message -p "#{client_termname}"); \
+if [ "$(tput -T "$client_termname" colors)" = "256" ] && \
+    infocmp "$TERM-256color" > /dev/null 2>&1; then \
+    TERM="$TERM-256color"; \
+fi; \
+\
+: " \
+Emulate the default \"default-command\" functionality of tmux. \
+Create a login shell using the \"default-shell\". \
+"; \
+default_shell=$(tmux display-message -p "#{default-shell}"); \
+exec $default_shell -l'
 
 #===========
 # Disable ESC key delay


### PR DESCRIPTION
Determine `TERM` value in `tmux`'s `default-command`.